### PR TITLE
Simplify annotation protocol

### DIFF
--- a/annotation_protocol/AnnotationProtocol.py
+++ b/annotation_protocol/AnnotationProtocol.py
@@ -5,7 +5,6 @@ from typing import (
     Protocol,
     Union,
     _get_protocol_attrs,
-    _ProtocolMeta,
     get_args,
     get_origin,
     runtime_checkable,
@@ -140,7 +139,7 @@ def _check_annotations(proto, other):
     return True
 
 
-class _AnnotationProtocolMeta(_ProtocolMeta):
+class _AnnotationProtocolMeta(type(Protocol)):
     def __instancecheck__(cls: Any, instance: Any) -> bool:
         if getattr(cls, "_is_protocol", False):
             for attr in _get_protocol_attrs(cls):
@@ -157,7 +156,7 @@ class _AnnotationProtocolMeta(_ProtocolMeta):
             )
             if isinstance(check, bool):
                 return check
-        return super(_ProtocolMeta, cls).__instancecheck__(instance)
+        return super(type(Protocol), cls).__instancecheck__(instance)
 
 
 class AnnotationProtocol(Protocol, metaclass=_AnnotationProtocolMeta):


### PR DESCRIPTION
- Added a few debug messages / slightly changed existing ones
- Using `_ProtocolMeta` instead of `type(Protocol)` in `_AnnotationProtocolMeta`

In line 158, why is `return super(_ProtocolMeta, cls).__instancecheck__(instance)` need instead of `return super().__instancecheck__(instance)`? Tests fail if I change it. However, in line 151 I was able to change it successfully without any failing tests.

The debug messages are still slightly convoluted. For instance, we send messages for each method signature that is compared irrespective of whether it fails, but we do not do so for attributes. Attributes only get debug messages when they are missing. I would propose to either add attributes to generic checking messages or to remove generic checking messages for methods and only keep debug messages for failures (adding generic messages for data attributes requires rewriting the metaclass, which I am not a big fan of).